### PR TITLE
Fixed decoder function for negative temperatures

### DIFF
--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -33,7 +33,10 @@ function Decoder(bytes, port) {
   decoded.event = events[port];
   decoded.battery = (bytes[0] << 8) + bytes[1];
   decoded.light = (bytes[2] << 8) + bytes[3];
-  decoded.temperature = ((bytes[4] << 8) + bytes[5]) / 100;
+  if (bytes[4] & 0x80)
+    decoded.temperature = ((0xffff << 16) + (bytes[4] << 8) + bytes[5]) / 100;
+  else
+    decoded.temperature = ((bytes[4] << 8) + bytes[5]) / 100;
   return decoded;
 }
 */

--- a/examples/Basic/Decoder.js
+++ b/examples/Basic/Decoder.js
@@ -24,7 +24,10 @@ function Decoder(bytes, port) {
   decoded.event = events[port];
   decoded.battery = (bytes[0] << 8) + bytes[1];
   decoded.light = (bytes[2] << 8) + bytes[3];
-  decoded.temperature = ((bytes[4] << 8) + bytes[5]) / 100;
+  if (bytes[4] & 0x80)
+    decoded.temperature = ((0xffff << 16) + (bytes[4] << 8) + bytes[5]) / 100;
+  else
+    decoded.temperature = ((bytes[4] << 8) + bytes[5]) / 100;
 
   return decoded;
 }


### PR DESCRIPTION
When negative numbers in 2-complement get converted from 16-bit (Arduino) to 32-bit (JavaScript), the sign bit has to be at bit 0, not at bit 17, as it was with the old code, which implicitly padded 16 zeroes to the left. As a result, the negative number -1 returns 65535.

By prefixing a 16-bit negative number with 16 ones, the correct 32-bit 2-complement number is constructed.